### PR TITLE
feat: SSR support

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<style type="text/css">
+  body {
+    margin: 0;
+    padding: 0;
+  }
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17264,11 +17264,6 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"use-debounce": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.3.0.tgz",
-			"integrity": "sha512-p6b0ZxTTpFDtds138PvfrWB98pCMOfA8/c0yHLm9CudJ5l1lqcA0Zg/3Y8KCF/ghMKzOcE1/IknnW7H3wF8RhQ=="
-		},
 		"util": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,15 +44,13 @@
 		"build-storybook": "build-storybook"
 	},
 	"peerDependencies": {
-		"lodash": "4.17.15",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dom": "16.12.0"
 	},
 	"dependencies": {
 		"react-spring": "8.0.27",
-		"react-use-gesture": "6.0.14",
-		"use-debounce": "^3.3.0"
+		"react-use-gesture": "6.0.14"
 	},
 	"devDependencies": {
 		"@babel/cli": "7.7.5",
@@ -71,7 +69,6 @@
 		"eslint-plugin-react-hooks": "2.3.0",
 		"husky": "3.1.0",
 		"lint-staged": "9.5.0",
-		"lodash": "4.17.15",
 		"parcel-bundler": "1.12.4",
 		"prettier": "1.19.1",
 		"prop-types": "15.7.2",

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -14,13 +14,20 @@ const onSlideChange = index => {
 	console.log(`Slide changed to: ${index}`);
 };
 
+const imageStyle = src => ({
+	backgroundSize: 'cover',
+	backgroundImage: `url(${src})`,
+	height: '100%',
+	width: '100%'
+});
+
 storiesOf('Slider', module)
 	.add('default', () => (
 		<div style={{width: '100vw', height: '100vh'}}>
 			<Slider hasBullets onSlideChange={onSlideChange}>
 				{images.map(image => (
 					<div key={image}>
-						<img draggable="false" src={image} />
+						<div draggable="false" style={imageStyle(image)} />
 					</div>
 				))}
 			</Slider>
@@ -31,7 +38,7 @@ storiesOf('Slider', module)
 			<Slider hasBullets>
 				{images.map(image => (
 					<div key={image}>
-						<img draggable="false" src={image} />
+						<div draggable="false" style={imageStyle(image)} />
 					</div>
 				))}
 			</Slider>
@@ -42,7 +49,7 @@ storiesOf('Slider', module)
 			<Slider bullets auto={2000}>
 				{images.map(image => (
 					<div key={image}>
-						<img draggable="false" src={image} />
+						<div draggable="false" style={imageStyle(image)} />
 					</div>
 				))}
 			</Slider>
@@ -53,7 +60,7 @@ storiesOf('Slider', module)
 			<Slider hasBullets activeIndex={2}>
 				{images.map(image => (
 					<div key={image}>
-						<img draggable="false" src={image} />
+						<div draggable="false" style={imageStyle(image)} />
 					</div>
 				))}
 			</Slider>
@@ -78,7 +85,7 @@ storiesOf('Slider', module)
 				<Slider hasBullets activeIndex={activeIndex}>
 					{images.map(image => (
 						<div key={image}>
-							<img draggable="false" src={image} />
+							<div draggable="false" style={imageStyle(image)} />
 						</div>
 					))}
 				</Slider>


### PR DESCRIPTION
- uses relative width & height to remove `window` dependency
- uses state to set current slide
- removes window resizing handlers
- removes lodash and debounce dependencies
- removes unnecessary wrapping div when rendering children
- cleanup variable names