### PR TITLE
fix(release): Run release on `main`-branch

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,5 @@
 {
+	"branches": ["main"],
 	"plugins": [
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",


### PR DESCRIPTION
> This test run was triggered on the branch main, while semantic-release is configured to only publish from master, therefore a new version won’t be published.

see:
https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches